### PR TITLE
Specify required role for entity history

### DIFF
--- a/inv-spec/paths/entities/history.yaml
+++ b/inv-spec/paths/entities/history.yaml
@@ -1,5 +1,7 @@
 get:
   summary: Get entities history as snapshots and diffs
+  description: |
+    **Requires to have admin rights**
   parameters:
     - $ref: ./partials/id.yaml
   tags:


### PR DESCRIPTION
On a side node, the endpoint answer with 403 when authenticated and 401 on https://api.inventaire.io/ when you try it