### PR TITLE
Add summaries endpoint

### DIFF
--- a/inv-spec/info.yaml
+++ b/inv-spec/info.yaml
@@ -10,6 +10,6 @@ description: |
 
   Beside this documentation, diving into the code is always an option: everything starts in the [router](https://github.com/inventaire/inventaire/blob/master/server/controllers/routes.coffee), and is then delegated to the [controllers](https://github.com/inventaire/inventaire/tree/master/server/controllers).
 
-  Then, feel welcome to [improve this documentation](https://github.com/inventaire/swagger-ui/tree/master/inv-spec)!
+  Then, feel welcome to [improve this documentation](https://github.com/inventaire/inventaire-api/tree/main/inv-spec)!
 
 version: "1.0.0"

--- a/inv-spec/paths/data/summaries.yaml
+++ b/inv-spec/paths/data/summaries.yaml
@@ -1,0 +1,16 @@
+get:
+  summary: An endpoint to get summaries
+  parameters:
+    - name: uri
+      in: query
+      description: An ISBN
+      required: true
+      type: string
+      x-example: 9782377290888
+    - name: langs
+      description: Filter to get only the desired language
+      required: false
+      type: string
+      x-example: fr
+  tags:
+    - Data


### PR DESCRIPTION
Hello there,

I noticed two things, the link to improve the documentation points to the old repo url, it still get redirected properly but I tought that it might be better to have the actual one.

Secondly I found that there was no documentation regarding the summaries endpoint.

Don't hesitate to tell if it's better to split the pull request per issue.
